### PR TITLE
Make gateway token optional (WIP)

### DIFF
--- a/programs/token-guard/src/guard_utils.rs
+++ b/programs/token-guard/src/guard_utils.rs
@@ -67,19 +67,23 @@ pub fn check_gateway_token(
     payer: &AccountInfo,
     token_guard: &ProgramAccount<TokenGuard>,
 ) -> ProgramResult {
-    msg!(
-        "Verifying gateway token {} on network {} belongs to {}",
-        gateway_token.key,
-        token_guard.gatekeeper_network,
-        payer.key()
-    );
+    if let Some(gatekeeper_network) = token_guard.gatekeeper_network {
+        msg!(
+            "Verifying gateway token {} on network {} belongs to {}",
+            gateway_token.key,
+            gatekeeper_network,
+            payer.key()
+        );
 
-    Gateway::verify_gateway_token_account_info(
-        &gateway_token,
-        &payer.key(),
-        &token_guard.gatekeeper_network,
-    )?;
-    msg!("Gateway token verified");
+        Gateway::verify_gateway_token_account_info(
+            &gateway_token,
+            &payer.key(),
+            &gatekeeper_network,
+        )?;
+        msg!("Gateway token verified");
+    } else {
+        msg!("Gateway token not required");
+    }
 
     Ok(())
 }

--- a/programs/token-guard/src/lib.rs
+++ b/programs/token-guard/src/lib.rs
@@ -26,7 +26,7 @@ pub mod token_guard {
     pub fn initialize(
         ctx: Context<Initialize>,
         mint_authority_bump: u8,
-        gatekeeper_network: Pubkey,
+        gatekeeper_network: Option<Pubkey>,
         start_time: Option<i64>,
         allowance: Option<u8>,
         max_amount: Option<u64>,
@@ -221,7 +221,7 @@ pub struct TokenGuard {
     pub authority: Pubkey,
     pub recipient: Pubkey,
     // pub recipient_ata: Pubkey,
-    pub gatekeeper_network: Pubkey,
+    pub gatekeeper_network: Option<Pubkey>,
     pub membership_token: Option<Pubkey>,
     pub out_mint: Pubkey,
     pub mint_authority_bump: u8,

--- a/programs/token-guard/src/lib.rs
+++ b/programs/token-guard/src/lib.rs
@@ -25,8 +25,8 @@ pub mod token_guard {
 
     pub fn initialize(
         ctx: Context<Initialize>,
-        gatekeeper_network: Pubkey,
         mint_authority_bump: u8,
+        gatekeeper_network: Pubkey,
         start_time: Option<i64>,
         allowance: Option<u8>,
         max_amount: Option<u64>,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -90,7 +90,11 @@ Mint: ${tokenGuardState.outMint}
 
 Additional Details:
 
-GatekeeperNetwork: ${tokenGuardState.gatekeeperNetwork}
+${
+  tokenGuardState.gatekeeperNetwork
+    ? `GatekeeperNetwork: ${tokenGuardState.gatekeeperNetwork}`
+    : "GatekeeperNetwork: Not required"
+}
 Recipient: ${tokenGuardState.recipient}
 MintAuthority: ${tokenGuardState.mintAuthority}
 ${

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -75,8 +75,8 @@ $ token-guard create -h
     const tokenGuardState = await initialize(
       program,
       provider,
-      flags.gatekeeperNetwork,
       flags.recipient,
+      flags.gatekeeperNetwork,
       flags.startTime,
       flags.allowance,
       flags.maxAmount,

--- a/src/lib/initialize.ts
+++ b/src/lib/initialize.ts
@@ -16,7 +16,7 @@ export const initialize = async (
   program: Program<TokenGuard>,
   provider: anchor.Provider,
   recipient: anchor.web3.PublicKey,
-  gatekeeperNetwork: anchor.web3.PublicKey,
+  gatekeeperNetwork?: anchor.web3.PublicKey,
   startTime?: number,
   allowance?: number,
   maxAmount?: number,
@@ -28,6 +28,7 @@ export const initialize = async (
     tokenGuard.publicKey,
     program
   );
+  const gatekeeperNetworkOrNull = gatekeeperNetwork || null;
   const startTimeBN = startTime ? new BN(startTime) : null;
   const allowanceOrNull = allowance || null;
   const maxAmountBN = maxAmount ? new BN(maxAmount) : null;
@@ -36,7 +37,7 @@ export const initialize = async (
 
   await program.rpc.initialize(
     mintAuthorityBump,
-    gatekeeperNetwork,
+    gatekeeperNetworkOrNull,
     startTimeBN,
     allowanceOrNull,
     maxAmountBN,

--- a/src/lib/initialize.ts
+++ b/src/lib/initialize.ts
@@ -15,8 +15,8 @@ const DECIMALS = 9; // lamports in 1 sol
 export const initialize = async (
   program: Program<TokenGuard>,
   provider: anchor.Provider,
-  gatekeeperNetwork: anchor.web3.PublicKey,
   recipient: anchor.web3.PublicKey,
+  gatekeeperNetwork: anchor.web3.PublicKey,
   startTime?: number,
   allowance?: number,
   maxAmount?: number,
@@ -35,8 +35,8 @@ export const initialize = async (
   const strategyValue = strategyToInt(membershipToken?.strategy);
 
   await program.rpc.initialize(
-    gatekeeperNetwork,
     mintAuthorityBump,
+    gatekeeperNetwork,
     startTimeBN,
     allowanceOrNull,
     maxAmountBN,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -35,7 +35,7 @@ export interface TokenGuardState {
   outMint: web3.PublicKey;
   recipient: web3.PublicKey;
   mintAuthority: web3.PublicKey;
-  gatekeeperNetwork: web3.PublicKey;
+  gatekeeperNetwork?: web3.PublicKey;
   membershipToken?: MembershipToken;
 }
 

--- a/tests/token-guard.ts
+++ b/tests/token-guard.ts
@@ -186,8 +186,8 @@ describe("token-guard", () => {
       tokenGuardState = await initialize(
         program,
         provider,
-        gatekeeperNetwork.publicKey,
-        recipient.publicKey
+        recipient.publicKey,
+        gatekeeperNetwork.publicKey
       );
 
       console.log({
@@ -295,8 +295,8 @@ describe("token-guard", () => {
       tokenGuardState = await initialize(
         program,
         provider,
-        gatekeeperNetwork.publicKey,
         recipient.publicKey,
+        gatekeeperNetwork.publicKey,
         Date.now() + 1_000_000
       );
     });
@@ -341,8 +341,8 @@ describe("token-guard", () => {
       tokenGuardState = await initialize(
         program,
         provider,
-        gatekeeperNetwork.publicKey,
         recipient.publicKey,
+        gatekeeperNetwork.publicKey,
         undefined,
         2
       );
@@ -376,8 +376,8 @@ describe("token-guard", () => {
       tokenGuardState = await initialize(
         program,
         provider,
-        gatekeeperNetwork.publicKey,
         recipient.publicKey,
+        gatekeeperNetwork.publicKey,
         undefined,
         undefined,
         exchangeAmount - 100 // smaller than the exchange amount
@@ -439,8 +439,8 @@ describe("token-guard", () => {
         tokenGuardState = await initialize(
           program,
           provider,
-          gatekeeperNetwork.publicKey,
           recipient.publicKey,
+          gatekeeperNetwork.publicKey,
           undefined,
           undefined,
           undefined,
@@ -634,8 +634,8 @@ describe("token-guard", () => {
           tokenGuardState = await initialize(
             program,
             provider,
-            gatekeeperNetwork.publicKey,
             recipient.publicKey,
+            gatekeeperNetwork.publicKey,
             undefined,
             undefined,
             undefined,
@@ -685,8 +685,8 @@ describe("token-guard", () => {
           tokenGuardState = await initialize(
             program,
             provider,
-            gatekeeperNetwork.publicKey,
             recipient.publicKey,
+            gatekeeperNetwork.publicKey,
             undefined,
             undefined,
             undefined,
@@ -736,8 +736,8 @@ describe("token-guard", () => {
           tokenGuardState = await initialize(
             program,
             provider,
-            gatekeeperNetwork.publicKey,
             recipient.publicKey,
+            gatekeeperNetwork.publicKey,
             undefined,
             1,
             undefined,


### PR DESCRIPTION
(UNFINISHED)

This makes setting the Gatekeeper Network optional at the time of initializing the TokenGuard. When the gateway network is not set, sending a gateway token should not be required during the exchange.